### PR TITLE
Update ContextMenu.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ const MyComponent = () => (
 ```
 
 > The trigger must expose onContextMenu prop
+
+## Rules
+    A ContextMenu set in a child element to popup instead an eventual ContextMenu set in parent.
+    the ContextMenu position is updataed at each right click.
+    The ContextMenu is removed when a click is done out of this ContextMenu.
+    the ContextMenu is not triggered when "ctrl" is hold

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -43,18 +43,25 @@ class ContextMenu extends React.Component {
   };
 
   handleContextMenu = evt => {
-    const { onContextMenu } = this.props;
+	if (!evt.ctrlKey) {
+		this.unmountContent();
+	  const { onContextMenu } = this.props;
+		evt.stopPropagation();
+	  evt.preventDefault();
+	  this.mountContent(evt);
+	  onContextMenu(evt);
+	}
+  };
 
-    evt.preventDefault();
-    this.mountContent(evt);
-    onContextMenu(evt);
+   handleOnClick = evt => {
+		this.unmountContent();
   };
 
   render() {
     const { trigger } = this.props;
 
     return cloneElement(trigger, {
-      onContextMenu: this.handleContextMenu
+      onContextMenu: this.handleContextMenu, onClick: this.handleOnClick
     });
   }
 }


### PR DESCRIPTION
This update allow:

- A ContextMenu set in a child element to popup instead an eventual ContextMenu set in parent.
- To update the ContextMenu position at each right click.
- To remove the ContextMenu when a click is done out of this ContextMenu. 
- To not trigger the ContextMenu when "ctrl" is hold